### PR TITLE
fix(tsconfig): wrong usage information in README for TS 3.1.x

### DIFF
--- a/lib/tsconfig/3.1.x/README.md
+++ b/lib/tsconfig/3.1.x/README.md
@@ -12,9 +12,11 @@ Adapt the content of your `tsconfig.json` file as follows:
 
 ```json
 {
-	"extends": "@nationalbankbelgium/code-style/tsconfig/3.1.x",
+	"extends": "./node_modules/@nationalbankbelgium/code-style/tsconfig/3.1.x/tsconfig.json",
 	"compilerOptions": {
 		// your configuration
 	}
 }
 ```
+
+Since TypeScript 3.2, there is a new way to extend a configuration. More information on [TypeScript Wiki](https://github.com/microsoft/TypeScript/wiki/What%27s-new-in-TypeScript#tsconfigjson-inheritance-via-nodejs-packages)

--- a/lib/tsconfig/3.1.x/ng7/README.md
+++ b/lib/tsconfig/3.1.x/ng7/README.md
@@ -12,9 +12,11 @@ Adapt the content of your `tsconfig.json` file as follows:
 
 ```json
 {
-	"extends": "@nationalbankbelgium/code-style/tsconfig/3.1.x/ng7",
+	"extends": "./node_modules/@nationalbankbelgium/code-style/tsconfig/3.1.x/ng7/tsconfig.json",
 	"compilerOptions": {
 		// your configuration
 	}
 }
 ```
+
+Since TypeScript 3.2, there is a new way to extend a configuration. More information on [TypeScript Wiki](https://github.com/microsoft/TypeScript/wiki/What%27s-new-in-TypeScript#tsconfigjson-inheritance-via-nodejs-packages)

--- a/lib/tsconfig/README.md
+++ b/lib/tsconfig/README.md
@@ -17,11 +17,25 @@ The following versions are available (based on **TypeScript** version and **Angu
 
 Adapt the content of your `tsconfig.json` file as follows:
 
+For TypeScript >= 3.2
+
 ```json
 {
-	"extends": "@nationalbankbelgium/code-style/tsconfig/3.1.x",
+	"extends": "@nationalbankbelgium/code-style/tsconfig/3.2.x",
 	"compilerOptions": {
 		// your configuration
 	}
 }
 ```
+
+For TypeScript < 3.2
+```json
+{
+	"extends": "./node_modules/@nationalbankbelgium/code-style/tsconfig/3.1.x/tsconfig.json",
+	"compilerOptions": {
+		// your configuration
+	}
+}
+```
+
+Since TypeScript 3.2, there is a new way to extend a configuration. More information on [TypeScript Wiki](https://github.com/microsoft/TypeScript/wiki/What%27s-new-in-TypeScript#tsconfigjson-inheritance-via-nodejs-packages)


### PR DESCRIPTION
More info:
https://github.com/microsoft/TypeScript/wiki/What%27s-new-in-TypeScript#tsconfigjson-inheritance-via-nodejs-packages

## PR Checklist

Please check if your PR fulfills the following requirements:

-   [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/code-style/blob/master/CONTRIBUTING.md#-commit-message-guidelines
-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[X] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Wrong information in README for Typescript 3.1.
The shown way to extend the config is wrong and does not work.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
Providing the right to extend a ts configuration when using typescript < 3.2

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
