### PR TITLE
fix(stylelint): comment unused rules

### DIFF
--- a/lib/stylelint/9.10.x/stylelint.config.js
+++ b/lib/stylelint/9.10.x/stylelint.config.js
@@ -148,12 +148,12 @@ module.exports = {
 		],
 
 		/*---------- These rules are handled by Prettier ----------*/
-		"function-comma-space-after": [
-			"always",
-			{
-				message: "Always put a space after commas in functions to be consistent and improve readability."
-			}
-		],
+		// "function-comma-space-after": [
+		// 	"always",
+		// 	{
+		// 		message: "Always put a space after commas in functions to be consistent and improve readability."
+		// 	}
+		// ],
 		"function-comma-space-before": [
 			"never",
 			{
@@ -341,14 +341,14 @@ module.exports = {
 				message: "Never put spaces inside media feature parentheses to avoid unnecessary whitespace."
 			}
 		],
-		"at-rule-empty-line-before": [
-			"always",
-			{
-				ignore: ["after-comment", "blockless-after-same-name-blockless"],
-				ignoreAtRules: ["import"],
-				message: "Always put an empty line before each @ rule, except after a comment or for @import."
-			}
-		],
+		// "at-rule-empty-line-before": [
+		// 	"always",
+		// 	{
+		// 		ignore: ["after-comment", "blockless-after-same-name-blockless"],
+		// 		ignoreAtRules: ["import"],
+		// 		message: "Always put an empty line before each @ rule, except after a comment or for @import."
+		// 	}
+		// ],
 		"at-rule-name-space-after": [
 			"always",
 			{
@@ -367,12 +367,12 @@ module.exports = {
 				message: "Never put a newline after the ending @ rule semicolon to avoid unnecessary whitespace."
 			}
 		],
-		"number-leading-zero": [
-			"never",
-			{
-				message: "Should not contain leading zeros to avoid unnecessary code."
-			}
-		],
+		// "number-leading-zero": [
+		// 	"never",
+		// 	{
+		// 		message: "Should not contain leading zeros to avoid unnecessary code."
+		// 	}
+		// ],
 		"color-hex-case": [
 			"lower",
 			{


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/code-style/blob/master/CONTRIBUTING.md#-commit-message-guidelines
-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Some stylelint rules are enabled but we actually disable them in Stark, thanks to `stylelint-config-prettier`.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
Unused rules in Stark are commented to not force the developers to do to respect something that we don't respect 😛 

## Does this PR introduce a breaking change?

```
[X] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
