### PR TITLE
fix(tsconfig): replace rootDir by rootDirs to fix tsc issues

### DIFF
--- a/lib/tsconfig/3.1.x/tsconfig.json
+++ b/lib/tsconfig/3.1.x/tsconfig.json
@@ -43,7 +43,7 @@
     "target": "es5",
     "outDir": "./dist",
     "baseUrl": "./src",
-    "rootDir": "./src",
+    "rootDirs": ["./src"],
     "lib": ["dom", "dom.iterable", "es2017"],
     "typeRoots": ["./node_modules/@types"],
     "paths": {}

--- a/lib/tsconfig/3.2.x/tsconfig.json
+++ b/lib/tsconfig/3.2.x/tsconfig.json
@@ -44,7 +44,7 @@
     "target": "es5",
     "outDir": "./dist",
     "baseUrl": "./src",
-    "rootDir": "./src",
+    "rootDirs": ["./src"],
     "lib": ["dom", "dom.iterable", "es2017"],
     "typeRoots": ["./node_modules/@types"],
     "paths": {}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/code-style/blob/master/CONTRIBUTING.md#-commit-message-guidelines
-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Because of the `rootDir: "./src"`, we get lots of errors when using code-style/tsconfig in our Stark framework.

We get this kind of errors:
```shell
error TS6059: File '<path_to_stark_project>/stark/showcase/base.spec.ts' is not under
'rootDir' '<path_to_stark_project>/stark/showcase/node_modules/@nationalbankbelgium/code-style/tsconfig/3.2.x/ng7/src'
error TS6059: File '<path_to_stark_project>/stark/showcase/src/app/app-menu.config.ts' is not under
'rootDir' '<path_to_stark_project>/stark/showcase/node_modules/@nationalbankbelgium/code-style/tsconfig/3.2.x/ng7/src'.
'rootDir' is expected to contain all source files.
```

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

We set `rootDirs: ["./src"]` which is not blocking.

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
