### PR TITLE
fix(tsconfig): remove outDir, baseUrl, rootDir and typeRoots properties from tsconfig files

### DIFF
--- a/lib/tsconfig/3.1.x/tsconfig.json
+++ b/lib/tsconfig/3.1.x/tsconfig.json
@@ -41,11 +41,7 @@
     "suppressImplicitAnyIndexErrors": true,
     "suppressExcessPropertyErrors": false,
     "target": "es5",
-    "outDir": "./dist",
-    "baseUrl": "./src",
-    "rootDir": "./src",
     "lib": ["dom", "dom.iterable", "es2017"],
-    "typeRoots": ["./node_modules/@types"],
     "paths": {}
   },
   "exclude": ["node_modules", "dist"],

--- a/lib/tsconfig/3.2.x/tsconfig.json
+++ b/lib/tsconfig/3.2.x/tsconfig.json
@@ -42,11 +42,7 @@
     "suppressImplicitAnyIndexErrors": true,
     "suppressExcessPropertyErrors": false,
     "target": "es5",
-    "outDir": "./dist",
-    "baseUrl": "./src",
-    "rootDir": "./src",
     "lib": ["dom", "dom.iterable", "es2017"],
-    "typeRoots": ["./node_modules/@types"],
     "paths": {}
   },
   "exclude": ["node_modules", "dist"],


### PR DESCRIPTION
ISSUES CLOSED: #10

## PR Checklist

Please check if your PR fulfills the following requirements:

-   [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/code-style/blob/master/CONTRIBUTING.md#-commit-message-guidelines
-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #10

## What is the new behavior?
Unnecessary options in `tsconfig.json` are now removed.

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
