### PR TITLE
fix(tslint): remove the rules of TSLint v4.4+ from the 4.3.x subpackage

### DIFF
--- a/lib/tslint/5.10.x/README.md
+++ b/lib/tslint/5.10.x/README.md
@@ -1,0 +1,20 @@
+<h1 align="center">
+   code style - TSLint 5.10.x
+</h1>
+
+## About
+
+This sub-package hosts the [TSLint](https://palantir.github.io/tslint/) configuration for `TSLint` 5.10.x.
+
+## Usage
+
+Adapt the content of your `tslint.json` file as follows:
+
+```text
+{
+	"extends": ["tslint:latest", "whatever config", "@nationalbankbelgium/code-style/tslint/5.10.x"],
+	"rules": {
+		// your rules
+	}
+}
+```

--- a/lib/tslint/5.10.x/package.json
+++ b/lib/tslint/5.10.x/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@nationalbankbelgium/code-style/tslint/5.10.x",
+  "main": "tslint.json"
+}

--- a/lib/tslint/5.10.x/tslint.json
+++ b/lib/tslint/5.10.x/tslint.json
@@ -1,6 +1,6 @@
 {
   "rules": {
-    "member-access": [true, "check-accessor", "check-constructor"],
+    "member-access": [true, "check-accessor", "check-constructor", "check-parameter-property"],
     "member-ordering": [
       false,
       {
@@ -44,38 +44,56 @@
     "no-construct": true,
     "no-debugger": true,
     "no-duplicate-variable": true,
+    "no-dynamic-delete": false,
     "no-empty": [true, "allow-empty-catch"],
     "no-eval": true,
+    "no-implicit-dependencies": false,
+    "no-invalid-template-strings": true,
     "no-invalid-this": true,
     "no-null-keyword": true,
+    "no-object-literal-type-assertion": true,
+    "no-return-await": true,
     "no-shadowed-variable": true,
+    "no-sparse-arrays": true,
     "no-string-literal": false,
     "no-string-throw": true,
+    "no-submodule-imports": [false, "@nationalbankbelgium", "rxjs", "lodash", "core-js", "valdr", "angular-material"],
     "no-switch-case-fall-through": true,
+    "no-this-assignment": false,
+    "no-unnecessary-class": ["allow-static-only"],
     "no-unsafe-finally": true,
     "no-unused-expression": true,
     "no-var-keyword": true,
+    "prefer-conditional-expression": false,
+    "prefer-object-spread": true,
+    "prefer-template": false,
     "radix": true,
     "switch-default": true,
     "triple-equals": true,
     "use-isnan": true,
     "cyclomatic-complexity": [true, 20],
     "no-default-export": true,
+    "no-duplicate-imports": true,
     "no-mergeable-namespace": true,
     "no-require-imports": false,
     "object-literal-sort-keys": false,
-    "align": [false, "arguments", "statements", "parameters"],
+    "align": [false, "arguments", "statements", "parameters", "members", "elements"],
     "callable-types": true,
     "class-name": true,
     "comment-format": [true, "check-space"],
     "file-header": false,
+    "encoding": false,
     "interface-name": [false, "never-prefix"],
     "interface-over-type-literal": true,
-    "jsdoc-format": true,
+    "jsdoc-format": [true, "check-multiline-start"],
     "no-angle-bracket-type-assertion": false,
     "no-parameter-properties": false,
+    "no-redundant-jsdoc": true,
+    "no-reference-import": true,
+    "no-unnecessary-callback-wrapper": false,
     "object-literal-shorthand": false,
     "one-variable-per-declaration": true,
+    "switch-final-break": false,
     "variable-name": [true, "check-format", "allow-leading-underscore", "allow-trailing-underscore", "ban-keywords"],
     "whitespace": [
       false,
@@ -84,8 +102,11 @@
       "check-operator",
       "check-module",
       "check-separator",
+      "check-rest-spread",
       "check-type",
-      "check-typecast"
+      "check-typecast",
+      "check-type-operator",
+      "check-preblock"
     ],
     "prefer-const": [
       true,
@@ -99,17 +120,57 @@
     "max-classes-per-file": false, // [true, 1],
     "prefer-for-of": true,
     "array-type": false, // [true, "array"]
+    "arrow-return-shorthand": true,
+    "binary-expression-operand-order": false,
+    "no-unnecessary-initializer": true,
+    "no-misused-new": true,
+    "prefer-method-signature": false,
+    "prefer-switch": [
+      true,
+      {
+        "min-cases": 3
+      }
+    ],
+    "prefer-function-over-method": false,
+    "prefer-while": true,
+    "no-import-side-effect": [
+      true,
+      {
+        "ignore-module": "(reflect-metadata|core-js|ngrx-store|angular|moment|polyfills|vendor|typings|\\.css|\\.pcss)"
+      }
+    ],
+    "no-non-null-assertion": true,
+    "no-parameter-reassignment": false,
     "adjacent-overload-signatures": true,
+    "ban-comma-operator": false,
+    "ban-types": false,
+    "no-duplicate-super": true,
+    "no-duplicate-switch-case": true,
+    "newline-before-return": false,
+    "newline-per-chained-call": false,
 
     // TSlint rules that require type info
     "no-inferred-empty-object-type": true,
-    "no-void-expression": false,
+    "no-void-expression": [true, "ignore-arrow-function-shorthand"],
+    "no-boolean-literal-compare": true,
+    "no-unnecessary-qualifier": true,
+    "no-floating-promises": true,
+    "match-default-export-name": true,
+    "return-undefined": true,
+    "deprecation": true,
+    "use-default-type-parameter": true,
+    "await-promise": true,
     "no-for-in-array": true,
+    "no-unbound-method": [true, { "ignore-static": true, "whitelist": ["expect"], "allow-typeof": true }],
+    "no-unnecessary-type-assertion": true,
     "restrict-plus-operands": true
     //  "strict-boolean-expressions": true,
     //	"promise-function-async": true,
     //	"completed-docs": true,
+    //  "no-unsafe-any": true,
+    //  "strict-type-predicates": true,
     //  "no-use-before-declare": true, // only useful when using the var keyword
-    //  "no-unused-variable": true,
+    //  "no-unused-variable": true, // deprecated as from TSLint 5.11.0
+    //  "prefer-readonly": true,
   }
 }

--- a/lib/tslint/README.md
+++ b/lib/tslint/README.md
@@ -9,6 +9,7 @@ This sub-package hosts the [TSLint](https://palantir.github.io/tslint/) configur
 The following versions are available (based on **TSLint** version):
 
 -   4.3.x - `@nationalbankbelgium/code-style/tslint/4.3.x`
+-   5.10.x - `@nationalbankbelgium/code-style/tslint/5.10.x`
 
 ## Usage
 
@@ -16,7 +17,7 @@ Adapt the content of your `tslint.json` file as follows:
 
 ```text
 {
-	"extends": ["tslint:latest", "whatever config", "@nationalbankbelgium/code-style/tslint/4.3.x"],
+	"extends": ["tslint:latest", "whatever config", "@nationalbankbelgium/code-style/tslint/5.10.x"],
 	"rules": {
 		// your rules
 	}


### PR DESCRIPTION
- move current 4.3.x config to a new 5.10.x subpackage

ISSUES CLOSED: #14

## PR Checklist

Please check if your PR fulfills the following requirements:

-   [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/code-style/blob/master/CONTRIBUTING.md#-commit-message-guidelines
-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[X] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[X] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #14 

## What is the new behavior?

- the existing TSLint config in the `4.3.x` subpackage has been copied to a new `5.10.x` subpackage, which is the latest version used in that config
- the rules from versions of TSLint higher than 4.3.x are removed from the config in the `4.3.x` subpackage.
- the rule [`no-void-expression`](https://palantir.github.io/tslint/rules/no-void-expression/) is now disabled in the subpackage `4.3.x` to avoid breaking changes due to the option `ignore-arrow-function-shorthand` (this rule option was added in [TSLint v5.1.0](https://github.com/palantir/tslint/blob/master/CHANGELOG.md#v510) and it is enabled in the config of our new `5.10.x` subpackage).

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```