### PR TITLE
fix(stylelint): disable 3 stylelint rules incorrectly enabled starting from stylelint 10.0.x

### DIFF
--- a/lib/stylelint/10.0.x/stylelint.config.js
+++ b/lib/stylelint/10.0.x/stylelint.config.js
@@ -153,12 +153,12 @@ module.exports = {
 		],
 
 		/*---------- These rules are handled by Prettier ----------*/
-		"function-comma-space-after": [
-			"always",
-			{
-				message: "Always put a space after commas in functions to be consistent and improve readability."
-			}
-		],
+		// "function-comma-space-after": [
+		// 	"always",
+		// 	{
+		// 		message: "Always put a space after commas in functions to be consistent and improve readability."
+		// 	}
+		// ],
 		"function-comma-space-before": [
 			"never",
 			{
@@ -346,14 +346,14 @@ module.exports = {
 				message: "Never put spaces inside media feature parentheses to avoid unnecessary whitespace."
 			}
 		],
-		"at-rule-empty-line-before": [
-			"always",
-			{
-				ignore: ["after-comment", "blockless-after-same-name-blockless"],
-				ignoreAtRules: ["import"],
-				message: "Always put an empty line before each @ rule, except after a comment or for @import."
-			}
-		],
+		// "at-rule-empty-line-before": [
+		// 	"always",
+		// 	{
+		// 		ignore: ["after-comment", "blockless-after-same-name-blockless"],
+		// 		ignoreAtRules: ["import"],
+		// 		message: "Always put an empty line before each @ rule, except after a comment or for @import."
+		// 	}
+		// ],
 		"at-rule-name-space-after": [
 			"always",
 			{
@@ -372,12 +372,12 @@ module.exports = {
 				message: "Never put a newline after the ending @ rule semicolon to avoid unnecessary whitespace."
 			}
 		],
-		"number-leading-zero": [
-			"never",
-			{
-				message: "Should not contain leading zeros to avoid unnecessary code."
-			}
-		],
+		// "number-leading-zero": [
+		// 	"never",
+		// 	{
+		// 		message: "Should not contain leading zeros to avoid unnecessary code."
+		// 	}
+		// ],
 		"color-hex-case": [
 			"lower",
 			{

--- a/lib/stylelint/10.1.x/stylelint.config.js
+++ b/lib/stylelint/10.1.x/stylelint.config.js
@@ -153,12 +153,12 @@ module.exports = {
 		],
 
 		/*---------- These rules are handled by Prettier ----------*/
-		"function-comma-space-after": [
-			"always",
-			{
-				message: "Always put a space after commas in functions to be consistent and improve readability."
-			}
-		],
+		// "function-comma-space-after": [
+		// 	"always",
+		// 	{
+		// 		message: "Always put a space after commas in functions to be consistent and improve readability."
+		// 	}
+		// ],
 		"function-comma-space-before": [
 			"never",
 			{
@@ -307,7 +307,7 @@ module.exports = {
 		"selector-descendant-combinator-no-non-space": [
 			true,
 			{
-				message: "Don't put  tabs, newlines, nor multiple spaces between selector descendants to improve readability."
+				message: "Don't put tabs, newlines, nor multiple spaces between selector descendants to improve readability."
 			}
 		],
 		"selector-list-comma-newline-after": [
@@ -346,14 +346,14 @@ module.exports = {
 				message: "Never put spaces inside media feature parentheses to avoid unnecessary whitespace."
 			}
 		],
-		"at-rule-empty-line-before": [
-			"always",
-			{
-				ignore: ["after-comment", "blockless-after-same-name-blockless"],
-				ignoreAtRules: ["import"],
-				message: "Always put an empty line before each @ rule, except after a comment or for @import."
-			}
-		],
+		// "at-rule-empty-line-before": [
+		// 	"always",
+		// 	{
+		// 		ignore: ["after-comment", "blockless-after-same-name-blockless"],
+		// 		ignoreAtRules: ["import"],
+		// 		message: "Always put an empty line before each @ rule, except after a comment or for @import."
+		// 	}
+		// ],
 		"at-rule-name-space-after": [
 			"always",
 			{
@@ -372,12 +372,12 @@ module.exports = {
 				message: "Never put a newline after the ending @ rule semicolon to avoid unnecessary whitespace."
 			}
 		],
-		"number-leading-zero": [
-			"never",
-			{
-				message: "Should not contain leading zeros to avoid unnecessary code."
-			}
-		],
+		// "number-leading-zero": [
+		// 	"never",
+		// 	{
+		// 		message: "Should not contain leading zeros to avoid unnecessary code."
+		// 	}
+		// ],
 		"color-hex-case": [
 			"lower",
 			{

--- a/lib/stylelint/11.0.x/stylelint.config.js
+++ b/lib/stylelint/11.0.x/stylelint.config.js
@@ -153,12 +153,12 @@ module.exports = {
 		],
 
 		/*---------- These rules are handled by Prettier ----------*/
-		"function-comma-space-after": [
-			"always",
-			{
-				message: "Always put a space after commas in functions to be consistent and improve readability."
-			}
-		],
+		// "function-comma-space-after": [
+		// 	"always",
+		// 	{
+		// 		message: "Always put a space after commas in functions to be consistent and improve readability."
+		// 	}
+		// ],
 		"function-comma-space-before": [
 			"never",
 			{
@@ -346,14 +346,14 @@ module.exports = {
 				message: "Never put spaces inside media feature parentheses to avoid unnecessary whitespace."
 			}
 		],
-		"at-rule-empty-line-before": [
-			"always",
-			{
-				ignore: ["after-comment", "blockless-after-same-name-blockless"],
-				ignoreAtRules: ["import"],
-				message: "Always put an empty line before each @ rule, except after a comment or for @import."
-			}
-		],
+		// "at-rule-empty-line-before": [
+		// 	"always",
+		// 	{
+		// 		ignore: ["after-comment", "blockless-after-same-name-blockless"],
+		// 		ignoreAtRules: ["import"],
+		// 		message: "Always put an empty line before each @ rule, except after a comment or for @import."
+		// 	}
+		// ],
 		"at-rule-name-space-after": [
 			"always",
 			{
@@ -372,12 +372,12 @@ module.exports = {
 				message: "Never put a newline after the ending @ rule semicolon to avoid unnecessary whitespace."
 			}
 		],
-		"number-leading-zero": [
-			"never",
-			{
-				message: "Should not contain leading zeros to avoid unnecessary code."
-			}
-		],
+		// "number-leading-zero": [
+		// 	"never",
+		// 	{
+		// 		message: "Should not contain leading zeros to avoid unnecessary code."
+		// 	}
+		// ],
 		"color-hex-case": [
 			"lower",
 			{

--- a/lib/stylelint/11.1.x/stylelint.config.js
+++ b/lib/stylelint/11.1.x/stylelint.config.js
@@ -153,12 +153,12 @@ module.exports = {
 		],
 
 		/*---------- These rules are handled by Prettier ----------*/
-		"function-comma-space-after": [
-			"always",
-			{
-				message: "Always put a space after commas in functions to be consistent and improve readability."
-			}
-		],
+		// "function-comma-space-after": [
+		// 	"always",
+		// 	{
+		// 		message: "Always put a space after commas in functions to be consistent and improve readability."
+		// 	}
+		// ],
 		"function-comma-space-before": [
 			"never",
 			{
@@ -346,14 +346,14 @@ module.exports = {
 				message: "Never put spaces inside media feature parentheses to avoid unnecessary whitespace."
 			}
 		],
-		"at-rule-empty-line-before": [
-			"always",
-			{
-				ignore: ["after-comment", "blockless-after-same-name-blockless"],
-				ignoreAtRules: ["import"],
-				message: "Always put an empty line before each @ rule, except after a comment or for @import."
-			}
-		],
+		// "at-rule-empty-line-before": [
+		// 	"always",
+		// 	{
+		// 		ignore: ["after-comment", "blockless-after-same-name-blockless"],
+		// 		ignoreAtRules: ["import"],
+		// 		message: "Always put an empty line before each @ rule, except after a comment or for @import."
+		// 	}
+		// ],
 		"at-rule-name-space-after": [
 			"always",
 			{
@@ -372,12 +372,12 @@ module.exports = {
 				message: "Never put a newline after the ending @ rule semicolon to avoid unnecessary whitespace."
 			}
 		],
-		"number-leading-zero": [
-			"never",
-			{
-				message: "Should not contain leading zeros to avoid unnecessary code."
-			}
-		],
+		// "number-leading-zero": [
+		// 	"never",
+		// 	{
+		// 		message: "Should not contain leading zeros to avoid unnecessary code."
+		// 	}
+		// ],
 		"color-hex-case": [
 			"lower",
 			{

--- a/lib/stylelint/12.0.x/stylelint.config.js
+++ b/lib/stylelint/12.0.x/stylelint.config.js
@@ -153,12 +153,12 @@ module.exports = {
 		],
 
 		/*---------- These rules are handled by Prettier ----------*/
-		"function-comma-space-after": [
-			"always",
-			{
-				message: "Always put a space after commas in functions to be consistent and improve readability."
-			}
-		],
+		// "function-comma-space-after": [
+		// 	"always",
+		// 	{
+		// 		message: "Always put a space after commas in functions to be consistent and improve readability."
+		// 	}
+		// ],
 		"function-comma-space-before": [
 			"never",
 			{
@@ -346,14 +346,14 @@ module.exports = {
 				message: "Never put spaces inside media feature parentheses to avoid unnecessary whitespace."
 			}
 		],
-		"at-rule-empty-line-before": [
-			"always",
-			{
-				ignore: ["after-comment", "blockless-after-same-name-blockless"],
-				ignoreAtRules: ["import"],
-				message: "Always put an empty line before each @ rule, except after a comment or for @import."
-			}
-		],
+		// "at-rule-empty-line-before": [
+		// 	"always",
+		// 	{
+		// 		ignore: ["after-comment", "blockless-after-same-name-blockless"],
+		// 		ignoreAtRules: ["import"],
+		// 		message: "Always put an empty line before each @ rule, except after a comment or for @import."
+		// 	}
+		// ],
 		"at-rule-name-space-after": [
 			"always",
 			{
@@ -372,12 +372,12 @@ module.exports = {
 				message: "Never put a newline after the ending @ rule semicolon to avoid unnecessary whitespace."
 			}
 		],
-		"number-leading-zero": [
-			"never",
-			{
-				message: "Should not contain leading zeros to avoid unnecessary code."
-			}
-		],
+		// "number-leading-zero": [
+		// 	"never",
+		// 	{
+		// 		message: "Should not contain leading zeros to avoid unnecessary code."
+		// 	}
+		// ],
 		"color-hex-case": [
 			"lower",
 			{

--- a/lib/stylelint/13.0.x/stylelint.config.js
+++ b/lib/stylelint/13.0.x/stylelint.config.js
@@ -153,12 +153,12 @@ module.exports = {
 		],
 
 		/*---------- These rules are handled by Prettier ----------*/
-		"function-comma-space-after": [
-			"always",
-			{
-				message: "Always put a space after commas in functions to be consistent and improve readability."
-			}
-		],
+		// "function-comma-space-after": [
+		// 	"always",
+		// 	{
+		// 		message: "Always put a space after commas in functions to be consistent and improve readability."
+		// 	}
+		// ],
 		"function-comma-space-before": [
 			"never",
 			{
@@ -346,14 +346,14 @@ module.exports = {
 				message: "Never put spaces inside media feature parentheses to avoid unnecessary whitespace."
 			}
 		],
-		"at-rule-empty-line-before": [
-			"always",
-			{
-				ignore: ["after-comment", "blockless-after-same-name-blockless"],
-				ignoreAtRules: ["import"],
-				message: "Always put an empty line before each @ rule, except after a comment or for @import."
-			}
-		],
+		// "at-rule-empty-line-before": [
+		// 	"always",
+		// 	{
+		// 		ignore: ["after-comment", "blockless-after-same-name-blockless"],
+		// 		ignoreAtRules: ["import"],
+		// 		message: "Always put an empty line before each @ rule, except after a comment or for @import."
+		// 	}
+		// ],
 		"at-rule-name-space-after": [
 			"always",
 			{
@@ -372,12 +372,12 @@ module.exports = {
 				message: "Never put a newline after the ending @ rule semicolon to avoid unnecessary whitespace."
 			}
 		],
-		"number-leading-zero": [
-			"never",
-			{
-				message: "Should not contain leading zeros to avoid unnecessary code."
-			}
-		],
+		// "number-leading-zero": [
+		// 	"never",
+		// 	{
+		// 		message: "Should not contain leading zeros to avoid unnecessary code."
+		// 	}
+		// ],
 		"color-hex-case": [
 			"lower",
 			{


### PR DESCRIPTION
Disabled rules:
  - `function-comma-space-after`
  - `at-rule-empty-line-before`
  - `number-leading-zero`

ISSUES CLOSED: #32

## PR Checklist

Please check if your PR fulfills the following requirements:

-   [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/code-style/blob/master/CONTRIBUTING.md#-commit-message-guidelines
-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #32

## What is the new behavior?

The following rules are now disabled as they should be:
  - `function-comma-space-after`
  - `at-rule-empty-line-before`
  - `number-leading-zero`

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
