### PR TITLE
Feature/tslint improve typecheck config

### DIFF
--- a/lib/tslint/5.10.x/tslint.json
+++ b/lib/tslint/5.10.x/tslint.json
@@ -14,7 +14,7 @@
     "no-namespace": [true, "allow-declarations"],
     "no-reference": true,
     "no-var-requires": false,
-    "typedef": [true, "call-signature", "arrow-call-signature", "parameter", "arrow-parameter", "property-declaration"],
+    "typedef": [true, "call-signature", "parameter", "arrow-parameter", "property-declaration"],
     "typedef-whitespace": [
       false,
       {

--- a/lib/tslint/5.10.x/tslint.json
+++ b/lib/tslint/5.10.x/tslint.json
@@ -14,7 +14,7 @@
     "no-namespace": [true, "allow-declarations"],
     "no-reference": true,
     "no-var-requires": false,
-    "typedef": [true, "call-signature", "parameter", "arrow-parameter", "property-declaration"],
+    "typedef": [true, "call-signature", "parameter", "property-declaration"],
     "typedef-whitespace": [
       false,
       {

--- a/lib/tslint/5.11.x/tslint.json
+++ b/lib/tslint/5.11.x/tslint.json
@@ -14,7 +14,7 @@
     "no-namespace": [true, "allow-declarations"],
     "no-reference": true,
     "no-var-requires": false,
-    "typedef": [true, "call-signature", "arrow-call-signature", "parameter", "arrow-parameter", "property-declaration"],
+    "typedef": [true, "call-signature", "parameter", "arrow-parameter", "property-declaration"],
     "typedef-whitespace": [
       false,
       {

--- a/lib/tslint/5.11.x/tslint.json
+++ b/lib/tslint/5.11.x/tslint.json
@@ -14,7 +14,7 @@
     "no-namespace": [true, "allow-declarations"],
     "no-reference": true,
     "no-var-requires": false,
-    "typedef": [true, "call-signature", "parameter", "arrow-parameter", "property-declaration"],
+    "typedef": [true, "call-signature", "parameter", "property-declaration"],
     "typedef-whitespace": [
       false,
       {

--- a/lib/tslint/5.12.x/tslint.json
+++ b/lib/tslint/5.12.x/tslint.json
@@ -14,7 +14,7 @@
     "no-namespace": [true, "allow-declarations"],
     "no-reference": true,
     "no-var-requires": false,
-    "typedef": [true, "call-signature", "arrow-call-signature", "parameter", "arrow-parameter", "property-declaration"],
+    "typedef": [true, "call-signature", "parameter", "arrow-parameter", "property-declaration"],
     "typedef-whitespace": [
       false,
       {

--- a/lib/tslint/5.12.x/tslint.json
+++ b/lib/tslint/5.12.x/tslint.json
@@ -14,7 +14,7 @@
     "no-namespace": [true, "allow-declarations"],
     "no-reference": true,
     "no-var-requires": false,
-    "typedef": [true, "call-signature", "parameter", "arrow-parameter", "property-declaration"],
+    "typedef": [true, "call-signature", "parameter", "property-declaration"],
     "typedef-whitespace": [
       false,
       {

--- a/lib/tslint/5.13.x/tslint.json
+++ b/lib/tslint/5.13.x/tslint.json
@@ -14,7 +14,7 @@
     "no-namespace": [true, "allow-declarations"],
     "no-reference": true,
     "no-var-requires": false,
-    "typedef": [true, "call-signature", "arrow-call-signature", "parameter", "arrow-parameter", "property-declaration"],
+    "typedef": [true, "call-signature", "parameter", "arrow-parameter", "property-declaration"],
     "typedef-whitespace": [
       false,
       {

--- a/lib/tslint/5.13.x/tslint.json
+++ b/lib/tslint/5.13.x/tslint.json
@@ -14,7 +14,7 @@
     "no-namespace": [true, "allow-declarations"],
     "no-reference": true,
     "no-var-requires": false,
-    "typedef": [true, "call-signature", "parameter", "arrow-parameter", "property-declaration"],
+    "typedef": [true, "call-signature", "parameter", "property-declaration"],
     "typedef-whitespace": [
       false,
       {

--- a/lib/tslint/5.14.x/tslint.json
+++ b/lib/tslint/5.14.x/tslint.json
@@ -14,7 +14,7 @@
     "no-namespace": [true, "allow-declarations"],
     "no-reference": true,
     "no-var-requires": false,
-    "typedef": [true, "call-signature", "arrow-call-signature", "parameter", "arrow-parameter", "property-declaration"],
+    "typedef": [true, "call-signature", "parameter", "arrow-parameter", "property-declaration"],
     "typedef-whitespace": [
       false,
       {

--- a/lib/tslint/5.14.x/tslint.json
+++ b/lib/tslint/5.14.x/tslint.json
@@ -14,7 +14,7 @@
     "no-namespace": [true, "allow-declarations"],
     "no-reference": true,
     "no-var-requires": false,
-    "typedef": [true, "call-signature", "parameter", "arrow-parameter", "property-declaration"],
+    "typedef": [true, "call-signature", "parameter", "property-declaration"],
     "typedef-whitespace": [
       false,
       {

--- a/lib/tslint/5.15.x/tslint.json
+++ b/lib/tslint/5.15.x/tslint.json
@@ -14,7 +14,7 @@
     "no-namespace": [true, "allow-declarations"],
     "no-reference": true,
     "no-var-requires": false,
-    "typedef": [true, "call-signature", "arrow-call-signature", "parameter", "arrow-parameter", "property-declaration"],
+    "typedef": [true, "call-signature", "parameter", "arrow-parameter", "property-declaration"],
     "typedef-whitespace": [
       false,
       {

--- a/lib/tslint/5.15.x/tslint.json
+++ b/lib/tslint/5.15.x/tslint.json
@@ -14,7 +14,7 @@
     "no-namespace": [true, "allow-declarations"],
     "no-reference": true,
     "no-var-requires": false,
-    "typedef": [true, "call-signature", "parameter", "arrow-parameter", "property-declaration"],
+    "typedef": [true, "call-signature", "parameter", "property-declaration"],
     "typedef-whitespace": [
       false,
       {

--- a/lib/tslint/5.16.x/tslint.json
+++ b/lib/tslint/5.16.x/tslint.json
@@ -14,7 +14,7 @@
     "no-namespace": [true, "allow-declarations"],
     "no-reference": true,
     "no-var-requires": false,
-    "typedef": [true, "call-signature", "arrow-call-signature", "parameter", "arrow-parameter", "property-declaration"],
+    "typedef": [true, "call-signature", "parameter", "arrow-parameter", "property-declaration"],
     "typedef-whitespace": [
       false,
       {

--- a/lib/tslint/5.16.x/tslint.json
+++ b/lib/tslint/5.16.x/tslint.json
@@ -14,7 +14,7 @@
     "no-namespace": [true, "allow-declarations"],
     "no-reference": true,
     "no-var-requires": false,
-    "typedef": [true, "call-signature", "parameter", "arrow-parameter", "property-declaration"],
+    "typedef": [true, "call-signature", "parameter", "property-declaration"],
     "typedef-whitespace": [
       false,
       {

--- a/lib/tslint/5.17.x/tslint.json
+++ b/lib/tslint/5.17.x/tslint.json
@@ -14,7 +14,7 @@
     "no-namespace": [true, "allow-declarations"],
     "no-reference": true,
     "no-var-requires": false,
-    "typedef": [true, "call-signature", "arrow-call-signature", "parameter", "arrow-parameter", "property-declaration"],
+    "typedef": [true, "call-signature", "parameter", "arrow-parameter", "property-declaration"],
     "typedef-whitespace": [
       false,
       {

--- a/lib/tslint/5.17.x/tslint.json
+++ b/lib/tslint/5.17.x/tslint.json
@@ -14,7 +14,7 @@
     "no-namespace": [true, "allow-declarations"],
     "no-reference": true,
     "no-var-requires": false,
-    "typedef": [true, "call-signature", "parameter", "arrow-parameter", "property-declaration"],
+    "typedef": [true, "call-signature", "parameter", "property-declaration"],
     "typedef-whitespace": [
       false,
       {

--- a/lib/tslint/5.18.x/tslint.json
+++ b/lib/tslint/5.18.x/tslint.json
@@ -14,7 +14,7 @@
     "no-namespace": [true, "allow-declarations"],
     "no-reference": true,
     "no-var-requires": false,
-    "typedef": [true, "call-signature", "arrow-call-signature", "parameter", "arrow-parameter", "property-declaration"],
+    "typedef": [true, "call-signature", "parameter", "arrow-parameter", "property-declaration"],
     "typedef-whitespace": [
       false,
       {

--- a/lib/tslint/5.18.x/tslint.json
+++ b/lib/tslint/5.18.x/tslint.json
@@ -14,7 +14,7 @@
     "no-namespace": [true, "allow-declarations"],
     "no-reference": true,
     "no-var-requires": false,
-    "typedef": [true, "call-signature", "parameter", "arrow-parameter", "property-declaration"],
+    "typedef": [true, "call-signature", "parameter", "property-declaration"],
     "typedef-whitespace": [
       false,
       {

--- a/lib/tslint/5.19.x/tslint.json
+++ b/lib/tslint/5.19.x/tslint.json
@@ -14,7 +14,7 @@
     "no-namespace": [true, "allow-declarations"],
     "no-reference": true,
     "no-var-requires": false,
-    "typedef": [true, "call-signature", "arrow-call-signature", "parameter", "arrow-parameter", "property-declaration"],
+    "typedef": [true, "call-signature", "parameter", "arrow-parameter", "property-declaration"],
     "typedef-whitespace": [
       false,
       {

--- a/lib/tslint/5.19.x/tslint.json
+++ b/lib/tslint/5.19.x/tslint.json
@@ -14,7 +14,7 @@
     "no-namespace": [true, "allow-declarations"],
     "no-reference": true,
     "no-var-requires": false,
-    "typedef": [true, "call-signature", "parameter", "arrow-parameter", "property-declaration"],
+    "typedef": [true, "call-signature", "parameter", "property-declaration"],
     "typedef-whitespace": [
       false,
       {

--- a/lib/tslint/5.20.x/tslint.json
+++ b/lib/tslint/5.20.x/tslint.json
@@ -14,7 +14,7 @@
     "no-namespace": [true, "allow-declarations"],
     "no-reference": true,
     "no-var-requires": false,
-    "typedef": [true, "call-signature", "arrow-call-signature", "parameter", "arrow-parameter", "property-declaration"],
+    "typedef": [true, "call-signature", "parameter", "arrow-parameter", "property-declaration"],
     "typedef-whitespace": [
       false,
       {

--- a/lib/tslint/5.20.x/tslint.json
+++ b/lib/tslint/5.20.x/tslint.json
@@ -14,7 +14,7 @@
     "no-namespace": [true, "allow-declarations"],
     "no-reference": true,
     "no-var-requires": false,
-    "typedef": [true, "call-signature", "parameter", "arrow-parameter", "property-declaration"],
+    "typedef": [true, "call-signature", "parameter", "property-declaration"],
     "typedef-whitespace": [
       false,
       {

--- a/lib/tslint/6.0.x/tslint.json
+++ b/lib/tslint/6.0.x/tslint.json
@@ -14,7 +14,7 @@
     "no-namespace": [true, "allow-declarations"],
     "no-reference": true,
     "no-var-requires": false,
-    "typedef": [true, "call-signature", "arrow-call-signature", "parameter", "arrow-parameter", "property-declaration"],
+    "typedef": [true, "call-signature", "parameter", "arrow-parameter", "property-declaration"],
     "typedef-whitespace": [
       false,
       {

--- a/lib/tslint/6.0.x/tslint.json
+++ b/lib/tslint/6.0.x/tslint.json
@@ -14,7 +14,7 @@
     "no-namespace": [true, "allow-declarations"],
     "no-reference": true,
     "no-var-requires": false,
-    "typedef": [true, "call-signature", "parameter", "arrow-parameter", "property-declaration"],
+    "typedef": [true, "call-signature", "parameter", "property-declaration"],
     "typedef-whitespace": [
       false,
       {

--- a/lib/tslint/6.1.x/tslint.json
+++ b/lib/tslint/6.1.x/tslint.json
@@ -14,7 +14,7 @@
     "no-namespace": [true, "allow-declarations"],
     "no-reference": true,
     "no-var-requires": false,
-    "typedef": [true, "call-signature", "arrow-call-signature", "parameter", "arrow-parameter", "property-declaration"],
+    "typedef": [true, "call-signature", "parameter", "arrow-parameter", "property-declaration"],
     "typedef-whitespace": [
       false,
       {

--- a/lib/tslint/6.1.x/tslint.json
+++ b/lib/tslint/6.1.x/tslint.json
@@ -14,7 +14,7 @@
     "no-namespace": [true, "allow-declarations"],
     "no-reference": true,
     "no-var-requires": false,
-    "typedef": [true, "call-signature", "parameter", "arrow-parameter", "property-declaration"],
+    "typedef": [true, "call-signature", "parameter", "property-declaration"],
     "typedef-whitespace": [
       false,
       {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/code-style/blob/master/CONTRIBUTING.md#-commit-message-guidelines
-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Inferred types are not supported in "arrow-parameter".

Arrow functions require signature even when it does not really make sense, see: 

```typescript
describe("Test description", () => {
  it("should set 'Hello World!', () => {
    expect(hello).toBe("Hello World!");
  });  
}
``` 

According to current rules, it should be

```typescript
// spec file

describe("Test description", (): void => {
  it("should set 'Hello World!', (): void => {
    expect(hello).toBe("Hello World!");
  });  
}
``` 

## What is the new behavior?

Disabling "arrow-call-signature" typedef rule to be aligned with current Stark configuration.

Disabling "arrow-parameter" typedef rule as inferred type is easy to use (ie: `createAction()` from "@ngrx/store").

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
