### PR TITLE
fix(build): fix GitHub CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,17 +18,17 @@ jobs:
     env:
       LOGS_DIR: /tmp/code-style/logs
       LOGS_FILE: /tmp/code-style/logs/build-perf.log
-      NPM_VERSION: "7.x"
+      NPM_VERSION: "8.x"
       TZ: "Europe/Brussels"
     steps:
       # See: https://github.com/marketplace/actions/checkout
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      # See: https://github.com/marketplace/actions/setup-node-js-for-use-with-actions
-      - name: Use Node.js 12
-        uses: actions/setup-node@v1
+      # See: https://github.com/marketplace/actions/setup-node-js-environment
+      - name: Use Node.js 14
+        uses: actions/setup-node@v4
         with:
-          node-version: "12"
+          node-version: "14"
 
       - name: Create file & folder for GitHub Actions logs
         run: |
@@ -37,14 +37,18 @@ jobs:
           touch $LOGS_FILE
 
       - name: Get tag name if exists
-        id: get_tag_name
-        run: echo ::set-output name=TAG_NAME::$(echo $GITHUB_REF | sed -n "s/^refs\/tags\/\(\S*\).*$/\1/p")
+        run: |
+          TAG_NAME=$(echo $GITHUB_REF | sed -n "s/^refs\/tags\/\(\S*\).*$/\1/p")
+          echo "GH_ACTIONS_TAG=${TAG_NAME}" >> $GITHUB_ENV
 
       - name: List main variables
         run: |
           echo "Commit SHA  : ${GITHUB_SHA}"
-          echo "Tag         : ${GH_ACTIONS_TAG}"
+          echo "Tag name    : ${GH_ACTIONS_TAG}"
           echo "Reference   : ${GITHUB_REF}"
+          echo "Head branch : ${GITHUB_HEAD_REF}"
+          echo "Base branch : ${GITHUB_BASE_REF}"
+          echo "Build number: ${GITHUB_RUN_NUMBER}"
           echo "Repository  : ${GITHUB_REPOSITORY}"
           echo "Event       : ${GITHUB_EVENT_NAME}"
           echo "Author      : ${GITHUB_ACTOR}"
@@ -65,8 +69,8 @@ jobs:
       - name: Build
         run: npm run build
 
-      # See: https://github.com/marketplace/actions/upload-artifact
-      - uses: actions/upload-artifact@v1
+      # See: https://github.com/marketplace/actions/upload-a-build-artifact
+      - uses: actions/upload-artifact@v3
         with:
           name: dist-${{ github.run_id }}
           path: dist
@@ -74,7 +78,6 @@ jobs:
       - name: Release
         run: npm run release:publish
         env:
-          GH_ACTIONS_TAG: ${{ steps.get_tag_name.outputs.TAG_NAME }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Save logs

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@commitlint/cli": "^16.2.1",
         "@commitlint/config-conventional": "^16.2.1",
         "@release-it/conventional-changelog": "^4.2.1",
+        "@types/node": "~14.14.31",
         "codelyzer": "~6.0.2",
         "commitizen": "^4.0.3",
         "conventional-changelog-cli": "^2.0.31",
@@ -1058,9 +1059,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "17.0.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
-      "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==",
+      "version": "14.14.45",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.45.tgz",
+      "integrity": "sha512-DssMqTV9UnnoxDWu959sDLZzfvqCF0qDNRjaWeYSui9xkFe61kKo4l1TWNTQONpuXEm+gLMRvdlzvNHBamzmEw==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -9201,13 +9202,15 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-9.0.0.tgz",
       "integrity": "sha512-ctjwuntPfZZT2mNj2NDIVu51t9cvbhl/16epc5xEwyzyDt76pX9UgwvY+MbXrf/C/FWwdtmNtfP698BKI+9leQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@angular/core": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-9.0.0.tgz",
       "integrity": "sha512-6Pxgsrf0qF9iFFqmIcWmjJGkkCaCm6V5QNnxMy2KloO3SDq6QuMVRbN9RtC8Urmo25LP+eZ6ZgYqFYpdD8Hd9w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@babel/code-frame": {
       "version": "7.14.5",
@@ -9847,7 +9850,8 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
       "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@octokit/plugin-rest-endpoint-methods": {
       "version": "5.13.0",
@@ -10018,9 +10022,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "17.0.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
-      "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==",
+      "version": "14.14.45",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.45.tgz",
+      "integrity": "sha512-DssMqTV9UnnoxDWu959sDLZzfvqCF0qDNRjaWeYSui9xkFe61kKo4l1TWNTQONpuXEm+gLMRvdlzvNHBamzmEw==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -14131,7 +14135,8 @@
       "version": "0.36.2",
       "resolved": "https://registry.npmjs.org/postcss-syntax/-/postcss-syntax-0.36.2.tgz",
       "integrity": "sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-value-parser": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@commitlint/cli": "^16.2.1",
     "@commitlint/config-conventional": "^16.2.1",
     "@release-it/conventional-changelog": "^4.2.1",
+    "@types/node": "~14.14.31",
     "codelyzer": "~6.0.2",
     "commitizen": "^4.0.3",
     "conventional-changelog-cli": "^2.0.31",

--- a/test.sh
+++ b/test.sh
@@ -67,8 +67,8 @@ do
   TEMP_CONFIG_PRETTIER="${testFolder}/prettier-test-file-${PRETTIER_VERSION}.js"
   logDebug "create temporary prettier config file: ${TEMP_CONFIG_PRETTIER}"
   echo "module.exports=require('../../lib/prettier/${PRETTIER_VERSION}/.prettierrc.js');" > ${TEMP_CONFIG_PRETTIER}
-  logDebug "run command \"npx prettier@${PRETTIER_VERSION} --config ${TEMP_CONFIG_PRETTIER} --write ${TEMP_TEST_PRETTIER}\""
-  testResult=$(npx prettier@${PRETTIER_VERSION} --config ${TEMP_CONFIG_PRETTIER} --write ${TEMP_TEST_PRETTIER} 2>&1)
+  logDebug "run command \"npx --yes prettier@${PRETTIER_VERSION} --config ${TEMP_CONFIG_PRETTIER} --write ${TEMP_TEST_PRETTIER}\""
+  testResult=$(npx --yes prettier@${PRETTIER_VERSION} --config ${TEMP_CONFIG_PRETTIER} --write ${TEMP_TEST_PRETTIER} 2>&1)
   if [[ ${testResult} == *"[warn] Ignored unknown"* ]]; then
     logInfo "The prettier configuration contains unknown rules"
     die ${testResult}
@@ -97,8 +97,8 @@ do
   TEMP_CONFIG_STYLELINT="${testFolder}/stylelint-test-file-${STYLELINT_VERSION}.json"
   logDebug "create temporary stylelint config file: ${TEMP_CONFIG_STYLELINT}"
   echo "{\"extends\":\"../../lib/stylelint/${STYLELINT_VERSION}/stylelint.config.js\"}" > ${TEMP_CONFIG_STYLELINT}
-  logDebug "run command \"npx stylelint@${STYLELINT_VERSION} --config ${TEMP_CONFIG_STYLELINT} ${TEMP_TEST_STYLELINT}\""
-  npx stylelint@${STYLELINT_VERSION} --config ${TEMP_CONFIG_STYLELINT} ${TEMP_TEST_STYLELINT}
+  logDebug "run command \"npx --yes stylelint@${STYLELINT_VERSION} --config ${TEMP_CONFIG_STYLELINT} ${TEMP_TEST_STYLELINT}\""
+  npx --yes stylelint@${STYLELINT_VERSION} --config ${TEMP_CONFIG_STYLELINT} ${TEMP_TEST_STYLELINT}
   ghActionsGroupEnd "validate stylelint ${STYLELINT_VERSION}"
 done
 
@@ -124,8 +124,8 @@ do
   TEMP_CONFIG_TSCONFIG="${testFolder}/tsconfig-test-file-${TSCONFIG_VERSION}.json"
   logDebug "create temporary tsconfig file: ${TEMP_CONFIG_TSCONFIG}"
   echo "{\"extends\":\"../../lib/tsconfig/${TSCONFIG_VERSION}/tsconfig.json\",\"compilerOptions\":{\"baseUrl\":\".\"}}" > ${TEMP_CONFIG_TSCONFIG}
-  logDebug "run command \"npx -p typescript@${TSCONFIG_VERSION} -c 'tsc -p ${TEMP_CONFIG_TSCONFIG}'\""
-  npx -p typescript@${TSCONFIG_VERSION} -c "tsc -p ${TEMP_CONFIG_TSCONFIG}"
+  logDebug "run command \"npx --yes -p typescript@${TSCONFIG_VERSION} -c 'tsc -p ${TEMP_CONFIG_TSCONFIG}'\""
+  npx --yes -p typescript@${TSCONFIG_VERSION} -c "tsc -p ${TEMP_CONFIG_TSCONFIG}"
   ghActionsGroupEnd "validate tsconfig ${TSCONFIG_VERSION}"
 done
 


### PR DESCRIPTION
Upgrade NodeJS to v14 and npm to v8.

Add `--yes` option to `npx` usage in "test.sh".

Add "@types/node": "~14.14.31" devDependency

## PR Checklist

Please check if your PR fulfills the following requirements:

-   [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/code-style/blob/master/CONTRIBUTING.md#-commit-message-guidelines
-   [X] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ x] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

CI workflow is using deprecated actions and commands. 

Tests are broken because of `npx` waiting for a user prompt + new version of `@types/node` breaks compatibility with TypeScript 3.x.

## What is the new behavior?

Upgrade all actions + adapt command to use the new `$GITHUB_ENV` + fix test.sh + add  "@types/node": "~14.14.31" devDependency

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
