### PR TITLE
fix(release): fix `@release-it/conventional-changelog` usage in .release-it.json

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -1,41 +1,41 @@
 {
-	"ci": false,
-	"dry-run": false,
-	"verbose": false,
-	"force": false,
-	"disable-metrics": true,
-	"hooks": {
-		"after:bump": "npm run generate:changelog"
-	},
-	"plugins": {
-		"@release-it/conventional-changelog": {
-			"preset": "angular"
-		}
-	},
-	"git": {
-		"changelog": "npm run generate:changelog-recent",
-		"requireCleanWorkingDir": true,
-		"requireUpstream": true,
-		"requireCommits": false,
-		"commit": true,
-		"commitMessage": "chore(release): release ${version}",
-		"commitArgs": "",
-		"tag": true,
-		"tagName": "${version}",
-		"tagAnnotation": "${version}",
-		"push": true,
-		"pushArgs": ["--follow-tags"],
-		"pushRepo": "origin"
-	},
-	"npm": {
-		"publish": false
-	},
-	"github": {
-		"release": true,
-		"releaseName": "Release ${version}",
-		"draft": false,
-		"tokenRef": "GITHUB_TOKEN",
-		"assets": null,
-		"host": null
-	}
+  "ci": false,
+  "dry-run": false,
+  "verbose": false,
+  "force": false,
+  "disable-metrics": true,
+  "hooks": {
+    "after:bump": "npm run generate:changelog"
+  },
+  "plugins": {
+    "@release-it/conventional-changelog": {
+      "preset": "angular"
+    }
+  },
+  "git": {
+    "changelog": "npm run generate:changelog-recent",
+    "requireCleanWorkingDir": true,
+    "requireUpstream": true,
+    "requireCommits": false,
+    "commit": true,
+    "commitMessage": "chore(release): release ${version}",
+    "commitArgs": "",
+    "tag": true,
+    "tagName": "${version}",
+    "tagAnnotation": "${version}",
+    "push": true,
+    "pushArgs": ["--follow-tags"],
+    "pushRepo": "origin"
+  },
+  "npm": {
+    "publish": false
+  },
+  "github": {
+    "release": true,
+    "releaseName": "Release ${version}",
+    "draft": false,
+    "tokenRef": "GITHUB_TOKEN",
+    "assets": null,
+    "host": null
+  }
 }

--- a/.release-it.json
+++ b/.release-it.json
@@ -9,7 +9,9 @@
   },
   "plugins": {
     "@release-it/conventional-changelog": {
-      "preset": "angular"
+      "preset": {
+        "name": "angular"
+      }
     }
   },
   "git": {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [X] The commit message follows our guidelines: https://github.com/NationalBankBelgium/code-style/blob/master/CONTRIBUTING.md#-commit-message-guidelines
-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[X] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

When running `release-it` command, we get the error:
```txt
The "angular" preset does not export a function. Maybe you are using an old version of the preset. Please upgrade
```

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

Adapt the .release-it.json file based on documentation on `@release-it/conventional-changelog` library.

See commit: https://github.com/release-it/conventional-changelog/commit/fa034ed1a5343426c76f5d660182995e0e4e014c 

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
